### PR TITLE
mailto typo closes #135

### DIFF
--- a/client/src/components/Information.tsx
+++ b/client/src/components/Information.tsx
@@ -446,7 +446,7 @@ const Information = () => {
               <br />
               Here is some information you may find useful:
               <br />
-              Our email <a href="mailto:info@mutualaid.wik ">info@mutualaid.wiki</a>
+              Our email <a href="mailto:info@mutualaid.wiki">info@mutualaid.wiki</a>
               <br />
               Our source code on{' '}
               <a href="https://github.com/Covid-Mutual-Aid/mutual-aid-wiki">github</a>

--- a/design/MAW_HOMEPAGE_04 2/index.html
+++ b/design/MAW_HOMEPAGE_04 2/index.html
@@ -227,7 +227,7 @@
 				<br><br>
 				Here is some information you may find useful:
 				<br>
-				Our email <a href="mailto:info@mutualaid.wik ">info@mutualaid.wiki</a><br>
+				Our email <a href="mailto:info@mutualaid.wiki">info@mutualaid.wiki</a><br>
 				Our source code on <a>github</a><br>
 				<br>
 				With ❤️ Mutual Aid Wiki team


### PR DESCRIPTION
Correct mailto typo, closes #135 

The mailto links here are missing the last i, and have a space instead:
https://github.com/Covid-Mutual-Aid/mutual-aid-wiki/search?q=info%40mutualaid.wik

```html
Our email <a href="mailto:info@mutualaid.wik ">info@mutualaid.wiki</a><br>
```

```tsx
Our email <a href="mailto:info@mutualaid.wik ">info@mutualaid.wiki</a>
```